### PR TITLE
修改了pdf中章节信息中"致谢"章节标题显示“thesisthesis致 谢致谢”的问题

### DIFF
--- a/template/hust.cls
+++ b/template/hust.cls
@@ -80,9 +80,11 @@
 }
 
 % 致谢标题
-\newcommand{\acknowledgement}{\sectionUnnumbered{\ifdefstring
-    {\HGP@mode}{thesis}{致\hspace{1em}谢}{致谢}
-}}
+\newcommand{\acknowledgement}{
+    \ifdefstring{\HGP@mode}
+        {thesis}{\sectionUnnumbered{致\hspace{1em}谢}}
+        {致谢}
+}
 
 % 文献翻译结尾插入原文
 \newcommand{\originalart}[1]{


### PR DESCRIPTION
<img width="628" height="540" alt="Screenshot 2026-04-29 at 12 48 27" src="https://github.com/user-attachments/assets/c9945d1b-e5a9-4245-a28b-98f2190f2d37" />
